### PR TITLE
sock_ntop.c: fix format-truncation error

### DIFF
--- a/libpcp/src/net/sock_ntop.c
+++ b/libpcp/src/net/sock_ntop.c
@@ -85,7 +85,7 @@ char *sock_ntop(const struct sockaddr *sa, socklen_t salen)
                     sizeof(str) - 1) == NULL)
                 return (NULL);
             if (ntohs(sin6->sin6_port) != 0) {
-                snprintf(portstr, sizeof(portstr) - 1, "]:%d",
+                snprintf(portstr, sizeof(portstr), "]:%d",
                         ntohs(sin6->sin6_port));
                 portstr[sizeof(portstr) - 1]='\0';
                 strcat(str, portstr);


### PR DESCRIPTION
Because snprintf can write 8 bytes, not 7

(Compilation with gcc 9.3.1 is broken)