### PR TITLE
libpcp: pcp_api: fix 64-bit time_t format

### DIFF
--- a/libpcp/src/pcp_api.c
+++ b/libpcp/src/pcp_api.c
@@ -261,8 +261,8 @@ pcp_fstate_e pcp_wait(pcp_flow_t *flow, int timeout, int exit_on_partial_res)
         FD_SET(fd, &read_fds);
 
         PCP_LOG(PCP_LOGLVL_DEBUG,
-                "Executing select with fdmax=%d, timeout = %ld s; %ld us",
-                fdmax, tout_select.tv_sec, (long int)tout_select.tv_usec);
+                "Executing select with fdmax=%d, timeout = %lld s; %ld us",
+                fdmax, (long long) tout_select.tv_sec, (long int)tout_select.tv_usec);
 
         ret_count=select(fdmax, &read_fds, NULL, NULL, &tout_select);
 


### PR DESCRIPTION
On newer systems `time_t` becomes 64-bit to allow handling of dates beyond Y2038, which yields to following compiler warning/error:

 src/pcp_api.c: In function 'pcp_wait':
 src/pcp_api.c:264:17: error: format '%ld' expects argument of type 'long int', but argument 4 has type 'time_t' {aka 'long long int'} [-Werror=format=]
   264 |                 "Executing select with fdmax=%d, timeout = %ld s; %ld us",
       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   265 |                 fdmax, tout_select.tv_sec, (long int)tout_select.tv_usec);
       |                        ~~~~~~~~~~~~~~~~~~
       |                                   |
       |                                   time_t {aka long long int}

So lets fix it by casting the older 32-bit `time_t` to 64-bit and use `%lld` format tag.

Signed-off-by: Petr Štetiar <ynezz@true.cz>